### PR TITLE
Remove redundant code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Yellow Systems
+Copyright (c) 2024 Yellow Systems
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UIDependent
 
-![CocoaPods Compatible](https://img.shields.io/badge/pod-v0.1.0-blue)
+![CocoaPods Compatible](https://img.shields.io/badge/pod-v0.1.1-blue)
 ![Platform](https://img.shields.io/badge/platform-iOS-yellow)
 ![Swift 5.x](https://img.shields.io/badge/Swift-5.x-orange)
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ view.frame.size = CGSize(width: 100.widthDependent(),
                          
 /// You can automatically convert the font sizes from the design according to the screen height of the running device:
 view.font = UIFont.boldSystemFont(ofSize: 18.fontSizeDependent())
-
-/// You can automatically convert the font sizes from the design according to the screen width of the running device:
-view.font = UIFont.boldSystemFont(ofSize: 18.fontSizeWidthDependent())
 ```
 
 If you need to use another values as the canonical height or width, you can pass them as arguments:
@@ -47,9 +44,6 @@ view.snp.makeConstraints {
 
 /// You can automatically convert the font sizes from the design according to the screen height of the running device:
 view.font = UIFont.boldSystemFont(ofSize: 18.fontSizeDependent(layoutHeight: 932))
-
-/// You can automatically convert the font sizes from the design according to the screen width of the running device:
-view.font = UIFont.boldSystemFont(ofSize: 18.fontSizeWidthDependent(layoutWidth: 430))
 ```
 
 Also, all methods have a `clamped` argument, which allows you to set the maximum and minimum size values:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ view.font = UIFont.boldSystemFont(ofSize: 10.fontSizeDependent(clamped: 8..<15))
 Nikita Grishin, nikita.hryshyn@yellow.systems
 Yellow Team
 
+## Contributors
+
+Artsiom Sadyryn, artsiom.sadyryn@yellow.systems
+
 ## License
 
 UIDependent is available under the MIT license. See the LICENSE file for more info.

--- a/UIDependent.podspec
+++ b/UIDependent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'UIDependent'
-  spec.version          = '0.1.0'
+  spec.version          = '0.1.1'
   spec.summary          = 'Yellow Systems UI sizes converters for iOS development'
 
   spec.description      = <<-DESC

--- a/UIDependent/UIDependent/Realization/Extensions/Numeric+Extensions.swift
+++ b/UIDependent/UIDependent/Realization/Extensions/Numeric+Extensions.swift
@@ -33,9 +33,4 @@ extension Numeric {
     func heightMultiplier(layoutHeight: CGFloat) -> CGFloat {
         UIScreen.main.bounds.height / layoutHeight
     }
-
-    func fontSizeMultiplier(layoutHeight: CGFloat) -> CGFloat {
-        let heightMultiplier = self.heightMultiplier(layoutHeight: layoutHeight)
-        return heightMultiplier >= 1 ? heightMultiplier : heightMultiplier
-    }
 }

--- a/UIDependent/UIDependent/Realization/Extensions/UISizeDependent+Extensions.swift
+++ b/UIDependent/UIDependent/Realization/Extensions/UISizeDependent+Extensions.swift
@@ -21,11 +21,6 @@ public extension UISizeDependent where Self: Numeric {
         cgFloat.dependent(multiplier: heightMultiplier(layoutHeight: layoutHeight))
     }
     
-    /// Device's screen font size width dependent value
-    func fontSizeWidthDependent(layoutWidth: CGFloat = .canonicalWidth) -> CGFloat {
-        cgFloat.dependent(multiplier: widthMultiplier(layoutWidth: layoutWidth))
-    }
-    
     // MARK: Clamped
     
     /// Device's screen width dependent value with range bounds
@@ -43,11 +38,6 @@ public extension UISizeDependent where Self: Numeric {
         fontSizeDependent(layoutHeight: layoutHeight).clamped(to: bounds)
     }
     
-    /// Device's screen font size width dependent value with range bounds
-    func fontSizeWidthDependent(layoutWidth: CGFloat = .canonicalWidth, clamped bounds: Range<CGFloat>) -> CGFloat {
-        fontSizeWidthDependent(layoutWidth: layoutWidth).clamped(to: bounds)
-    }
-    
     /// Device's screen width dependent value with range bounds
     func widthDependent(layoutWidth: CGFloat = .canonicalWidth, clamped bounds: PartialRangeThrough<CGFloat>) -> CGFloat {
         widthDependent(layoutWidth: layoutWidth).clamped(to: bounds)
@@ -63,11 +53,6 @@ public extension UISizeDependent where Self: Numeric {
         fontSizeDependent(layoutHeight: layoutHeight).clamped(to: bounds)
     }
     
-    /// Device's screen font size width dependent value with range bounds
-    func fontSizeWidthDependent(layoutWidth: CGFloat = .canonicalWidth, clamped bounds: PartialRangeThrough<CGFloat>) -> CGFloat {
-        fontSizeWidthDependent(layoutWidth: layoutWidth).clamped(to: bounds)
-    }
-    
     /// Device's screen width dependent value with range bounds
     func widthDependent(layoutWidth: CGFloat = .canonicalWidth, clamped bounds: PartialRangeFrom<CGFloat>) -> CGFloat {
         widthDependent(layoutWidth: layoutWidth).clamped(to: bounds)
@@ -81,10 +66,5 @@ public extension UISizeDependent where Self: Numeric {
     /// Device's screen font size height dependent value with range bounds
     func fontSizeDependent(layoutHeight: CGFloat = .canonicalHeight, clamped bounds: PartialRangeFrom<CGFloat>) -> CGFloat {
         fontSizeDependent(layoutHeight: layoutHeight).clamped(to: bounds)
-    }
-    
-    /// Device's screen font size width dependent value with range bounds
-    func fontSizeWidthDependent(layoutWidth: CGFloat = .canonicalWidth, clamped bounds: PartialRangeFrom<CGFloat>) -> CGFloat {
-        fontSizeWidthDependent(layoutWidth: layoutWidth).clamped(to: bounds)
     }
 }

--- a/UIDependent/UIDependent/Realization/Protocols/UISizeDependent.swift
+++ b/UIDependent/UIDependent/Realization/Protocols/UISizeDependent.swift
@@ -16,9 +16,6 @@ public protocol UISizeDependent {
 
     /// Device's screen font size height dependent value
     func fontSizeDependent(layoutHeight: CGFloat) -> CGFloat
-    
-    /// Device's screen font size width dependent value
-    func fontSizeWidthDependent(layoutWidth: CGFloat) -> CGFloat
 }
 
 extension Float: UISizeDependent { }


### PR DESCRIPTION
## Description:

- Remove the unused `fontSizeMultiplier` func
- Remove the redundant `fontSizeWidthDependent` func
- Add the `Contributors` section to README.md
- Bump the pod version to 0.1.1